### PR TITLE
Stop mutating `date` in createDateObjects method

### DIFF
--- a/src/createDateObjects.js
+++ b/src/createDateObjects.js
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 export default function createDateObjects(date, weekOffset = 0) {
-  const startOfMonth = date.startOf('month');
+  const startOfMonth = moment(date).startOf('month');
 
   let diff = startOfMonth.weekday() - weekOffset;
   if (diff < 0) diff += 7;


### PR DESCRIPTION
The original method resets the `date` to `startOf('month')` and this can be very confusing. It gave me a headache this afternoon fixing a state issue in a parent component.